### PR TITLE
Returned back index.md to internal links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: requirements-txt-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.4
+    rev: v0.11.5
     hooks:
       # Run the linter.
       - id: ruff

--- a/docs/1-introduction/index.md
+++ b/docs/1-introduction/index.md
@@ -27,12 +27,12 @@ As you explore Albumentations, you'll encounter these key ideas:
 Ready to dive in? Here are some recommended next steps:
 
 -   **[Installation](./installation.md):** Get Albumentations set up in your environment.
--   **[Core Concepts](../2-core-concepts):** Understand the building blocks:
+-   **[Core Concepts](../2-core-concepts/index.md):** Understand the building blocks:
     -   [Transforms](../2-core-concepts/transforms.md): Individual augmentation operations.
     -   [Pipelines (Compose)](../2-core-concepts/pipelines.md): Sequencing multiple transforms.
     -   [Targets](../2-core-concepts/targets.md): Applying transforms to images, masks, bounding boxes, etc.
     -   [Setting Probabilities](../2-core-concepts/probabilities.md): Controlling the likelihood of applying transforms.
--   **[Basic Usage Examples](../3-basic-usage):** See how to apply augmentations for common tasks like:
+-   **[Basic Usage Examples](../3-basic-usage/index.md):** See how to apply augmentations for common tasks like:
     -   [Image Classification](../3-basic-usage/image-classification.md)
     -   [Semantic Segmentation](../3-basic-usage/semantic-segmentation.md)
     -   [Bounding Box Augmentation](../3-basic-usage/bounding-boxes-augmentations.md)

--- a/docs/1-introduction/installation.md
+++ b/docs/1-introduction/installation.md
@@ -56,6 +56,6 @@ This should print the installed version number of Albumentations.
 
 Now that you have Albumentations installed, here are some logical next steps:
 
--   **[Understand Core Concepts](../2-core-concepts):** Learn about transforms, pipelines, targets, and probabilities – the fundamental building blocks of Albumentations.
--   **[See Basic Usage Examples](../3-basic-usage):** Explore how to apply augmentations for common computer vision tasks.
+-   **[Understand Core Concepts](../2-core-concepts/index.md):** Learn about transforms, pipelines, targets, and probabilities - the fundamental building blocks of Albumentations.
+-   **[See Basic Usage Examples](../3-basic-usage/index.md):** Explore how to apply augmentations for common computer vision tasks.
 -   **[Explore Transforms](https://explore.albumentations.ai):** Visually experiment with different augmentations and their parameters.

--- a/docs/1-introduction/what-are-image-augmentations.md
+++ b/docs/1-introduction/what-are-image-augmentations.md
@@ -131,9 +131,9 @@ While the concept is simple, effective implementation requires understanding you
 
 Now that you understand the concepts behind image augmentation, you might want to:
 
--   **[Get Started with Albumentations](..):** An overview of the library itself.
+-   **[Get Started with Albumentations](../index.md):** An overview of the library itself.
 -   **[Install Albumentations](./installation.md):** Set up the library in your environment.
--   **[Learn the Core Concepts](../2-core-concepts):** Understand how Albumentations implements transforms, pipelines, and target handling.
--   **[See Basic Usage Examples](../3-basic-usage):** Explore practical code for common tasks.
+-   **[Learn the Core Concepts](../2-core-concepts/index.md):** Understand how Albumentations implements transforms, pipelines, and target handling.
+-   **[See Basic Usage Examples](../3-basic-usage/index.md):** Explore practical code for common tasks.
 -   **[Read How to Pick Augmentations](../3-basic-usage/choosing-augmentations.md):** Get practical advice on selecting transforms for your specific problem.
 -   **[Explore Transforms Visually](https://explore.albumentations.ai):** Experiment with different augmentations and their effects.

--- a/docs/2-core-concepts/index.md
+++ b/docs/2-core-concepts/index.md
@@ -22,7 +22,7 @@ By grasping these concepts, you'll be well-equipped to design augmentation strat
 
 After familiarizing yourself with the core concepts, you can:
 
--   **[See Basic Usage Examples](../3-basic-usage):** Put the concepts into practice with code examples for common tasks like classification, segmentation, and object detection.
+-   **[See Basic Usage Examples](../3-basic-usage/index.md):** Put the concepts into practice with code examples for common tasks like classification, segmentation, and object detection.
 -   **[Learn How to Pick Augmentations](../3-basic-usage/choosing-augmentations.md):** Get guidance on selecting the right transforms for your specific problem.
--   **[Explore Advanced Guides](../4-advanced-guides):** Dive deeper into topics like creating custom transforms or serializing pipelines.
+-   **[Explore Advanced Guides](../4-advanced-guides/index.md):** Dive deeper into topics like creating custom transforms or serializing pipelines.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with individual transforms and their parameters interactively.

--- a/docs/2-core-concepts/pipelines.md
+++ b/docs/2-core-concepts/pipelines.md
@@ -318,6 +318,6 @@ Now that you understand how to build pipelines, consider these next steps:
 -   **[Transforms](./transforms.md):** Explore the individual augmentation operations you can include in your pipelines.
 -   **[Setting Probabilities](./probabilities.md):** Get a deeper understanding of how the `p` parameter works for both individual transforms and composition blocks.
 -   **[Working with Targets](./targets.md):** Learn how pipelines consistently apply augmentations to images, masks, bounding boxes, and keypoints.
--   **[Basic Usage Examples](../3-basic-usage):** See complete code examples of pipelines applied to common computer vision tasks.
--   **[Advanced Guides](../4-advanced-guides):** Discover techniques like serialization or creating custom transforms to integrate into your pipelines.
+-   **[Basic Usage Examples](../3-basic-usage/index.md):** See complete code examples of pipelines applied to common computer vision tasks.
+-   **[Advanced Guides](../4-advanced-guides/index.md):** Discover techniques like serialization or creating custom transforms to integrate into your pipelines.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with combining transforms in the interactive tool.

--- a/docs/2-core-concepts/probabilities.md
+++ b/docs/2-core-concepts/probabilities.md
@@ -99,6 +99,6 @@ Understanding probabilities is crucial for controlling your augmentation pipelin
 
 -   **[Review Pipelines](./pipelines.md):** See how probabilities function within different composition utilities like `Compose`, `OneOf`, `SomeOf`, and `Sequential`.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with different augmentations, their parameters, and consider the impact of their `p` values.
--   **[See Basic Usage Examples](../3-basic-usage):** Look at practical code applying pipelines with specific probabilities for different tasks.
+-   **[See Basic Usage Examples](../3-basic-usage/index.md):** Look at practical code applying pipelines with specific probabilities for different tasks.
 -   **[Learn How to Pick Augmentations](../3-basic-usage/choosing-augmentations.md):** Get insights into choosing appropriate transforms and their probabilities.
 -   **[Understand Reproducibility](../4-advanced-guides/creating-custom-transforms.md#reproducibility-and-random-number-generation):** Learn how seeds interact with probabilities to ensure consistent results when needed.

--- a/docs/2-core-concepts/transforms.md
+++ b/docs/2-core-concepts/transforms.md
@@ -94,5 +94,5 @@ With a grasp of individual transforms, you can:
 -   **Understand [Probabilities](./probabilities.md):** Dive deeper into how the `p` parameter controls transform application.
 -   **Study [Targets](./targets.md):** See how transforms interact with images, masks, bounding boxes, and keypoints.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Browse and experiment with the wide range of available augmentations.
--   **See [Basic Usage Examples](../3-basic-usage):** Look at practical code applying transforms and pipelines.
--   **Explore [Advanced Guides](../4-advanced-guides):** Learn about topics like creating your own custom transforms.
+-   **See [Basic Usage Examples](../3-basic-usage/index.md):** Look at practical code applying transforms and pipelines.
+-   **Explore [Advanced Guides](../4-advanced-guides/index.md):** Learn about topics like creating your own custom transforms.

--- a/docs/3-basic-usage/bounding-boxes-augmentations.md
+++ b/docs/3-basic-usage/bounding-boxes-augmentations.md
@@ -308,11 +308,11 @@ def visualize_bbox_augmentations(image, bboxes, labels, transform, samples=5):
 
 After mastering bounding box augmentation, you might want to:
 
--   **[Review Core Concepts](../2-core-concepts):** Solidify your understanding of [Targets](../2-core-concepts/targets.md) and [Pipelines](../2-core-concepts/pipelines.md).
+-   **[Review Core Concepts](../2-core-concepts/index.md):** Solidify your understanding of [Targets](../2-core-concepts/targets.md) and [Pipelines](../2-core-concepts/pipelines.md).
 -   **[Refine Your Augmentation Choices](./choosing-augmentations.md):** Get specific advice on selecting effective transforms for object detection.
 -   **[Optimize Performance](./performance-tuning.md):** Learn how to speed up your detection augmentation pipeline.
 -   **Explore Related Tasks:**
     -   [Keypoint Augmentation](./keypoint-augmentations.md)
     -   [Semantic Segmentation](./semantic-segmentation.md) (useful for instance segmentation alongside boxes)
--   **[Dive into Advanced Guides](../4-advanced-guides):** Learn about custom transforms, serialization, or handling additional targets.
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** Learn about custom transforms, serialization, or handling additional targets.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with different spatial and pixel-level transforms.

--- a/docs/3-basic-usage/choosing-augmentations.md
+++ b/docs/3-basic-usage/choosing-augmentations.md
@@ -515,5 +515,5 @@ Armed with strategies for choosing augmentations, you can now:
 -   **[Apply to Your Specific Task](./):** Integrate your chosen transforms into the pipeline for your task (e.g., Classification, Segmentation, Detection).
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment interactively with the specific transforms and parameters you are considering.
 -   **[Optimize Pipeline Speed](./performance-tuning.md):** Ensure your selected augmentation pipeline is efficient and doesn't bottleneck training.
--   **[Review Core Concepts](../2-core-concepts):** Reinforce your understanding of how pipelines, probabilities, and targets work with your chosen transforms.
--   **[Dive into Advanced Guides](../4-advanced-guides):** If standard transforms aren't enough, learn how to create custom ones.
+-   **[Review Core Concepts](../2-core-concepts/index.md):** Reinforce your understanding of how pipelines, probabilities, and targets work with your chosen transforms.
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** If standard transforms aren't enough, learn how to create custom ones.

--- a/docs/3-basic-usage/image-classification.md
+++ b/docs/3-basic-usage/image-classification.md
@@ -216,5 +216,5 @@ Here are some further resources to explore:
     -   [Object Detection](./bounding-boxes-augmentations.md)
     -   [Keypoint Augmentation](./keypoint-augmentations.md)
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Browse the full range of available augmentations and their effects.
--   **[Review Core Concepts](../2-core-concepts):** Reinforce your understanding of the library's fundamentals.
--   **[Check Advanced Guides](../4-advanced-guides):** Look into topics like custom transforms or serialization.
+-   **[Review Core Concepts](../2-core-concepts/index.md):** Reinforce your understanding of the library's fundamentals.
+-   **[Check Advanced Guides](../4-advanced-guides/index.md):** Look into topics like custom transforms or serialization.

--- a/docs/3-basic-usage/index.md
+++ b/docs/3-basic-usage/index.md
@@ -22,6 +22,6 @@ This section provides guides for common augmentation tasks, data types, and opti
 
 After exploring the basic usage examples relevant to your task, you might want to:
 
--   **[Dive into Advanced Guides](../4-advanced-guides):** Explore topics like creating custom transforms, serialization, or using additional targets.
--   **[Revisit Core Concepts](../2-core-concepts):** Solidify your understanding of transforms, pipelines, targets, and probabilities.
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** Explore topics like creating custom transforms, serialization, or using additional targets.
+-   **[Revisit Core Concepts](../2-core-concepts/index.md):** Solidify your understanding of transforms, pipelines, targets, and probabilities.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with the full range of available augmentations.

--- a/docs/3-basic-usage/keypoint-augmentations.md
+++ b/docs/3-basic-usage/keypoint-augmentations.md
@@ -223,11 +223,11 @@ Some augmentations may affect class labels and make them incorrect. For example,
 
 Now that you know how to augment keypoints, you might want to:
 
--   **[Review Core Concepts](../2-core-concepts):** Understand the fundamentals of [Targets](../2-core-concepts/targets.md) and [Pipelines](../2-core-concepts/pipelines.md).
+-   **[Review Core Concepts](../2-core-concepts/index.md):** Understand the fundamentals of [Targets](../2-core-concepts/targets.md) and [Pipelines](../2-core-concepts/pipelines.md).
 -   **[Refine Your Augmentation Choices](./choosing-augmentations.md):** Get advice on selecting transforms suitable for keypoint-based tasks (and be mindful of transforms like `HorizontalFlip` potentially affecting labels).
 -   **[Optimize Performance](./performance-tuning.md):** Learn how to speed up your augmentation pipeline.
 -   **Explore Related Tasks:**
     -   [Object Detection (Bounding Boxes)](./bounding-boxes-augmentations.md)
     -   [Semantic Segmentation](./semantic-segmentation.md)
--   **[Dive into Advanced Guides](../4-advanced-guides):** Explore custom transforms, serialization, or handling additional targets.
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** Explore custom transforms, serialization, or handling additional targets.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with different spatial and pixel-level augmentations.

--- a/docs/3-basic-usage/performance-tuning.md
+++ b/docs/3-basic-usage/performance-tuning.md
@@ -92,7 +92,7 @@ When each of your DataLoader workers spawns *multiple* OpenCV threads, they can 
 
 After optimizing your pipeline for speed, you might want to:
 
--   **[Apply to Your Task](./):** Return to the specific basic usage guides (e.g., Classification, Segmentation) and integrate these performance tips.
+-   **[Apply to Your Task](./index.md):** Return to the specific basic usage guides (e.g., Classification, Segmentation) and integrate these performance tips.
 -   **[Revisit Choosing Augmentations](./choosing-augmentations.md):** Evaluate the performance impact of the transforms you selected for generalization.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Check if combined transforms like `Affine` or `RandomResizedCrop` can replace multiple slower steps in your pipeline.
--   **[Dive into Advanced Guides](../4-advanced-guides/):** Explore further customization and optimization options.
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** Explore further customization and optimization options.

--- a/docs/3-basic-usage/semantic-segmentation.md
+++ b/docs/3-basic-usage/semantic-segmentation.md
@@ -306,6 +306,6 @@ With the basics of semantic segmentation augmentation covered, you might want to
 -   **Explore Related Tasks:**
     -   [Object Detection (Bounding Boxes)](./bounding-boxes-augmentations.md)
     -   [Keypoint Augmentation](./keypoint-augmentations.md)
--   **[Review Core Concepts](../2-core-concepts):** Revisit the fundamentals of [Targets](../2-core-concepts/targets.md) and [Pipelines](../2-core-concepts/pipelines.md).
--   **[Dive into Advanced Guides](../4-advanced-guides):** Explore custom transforms, serialization, or additional targets.
+-   **[Review Core Concepts](../2-core-concepts/index.md):** Revisit the fundamentals of [Targets](../2-core-concepts/targets.md) and [Pipelines](../2-core-concepts/pipelines.md).
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** Explore custom transforms, serialization, or additional targets.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with spatial transforms (like `ElasticTransform`, `GridDistortion`) and pixel-level transforms.

--- a/docs/3-basic-usage/video-augmentation.md
+++ b/docs/3-basic-usage/video-augmentation.md
@@ -285,7 +285,7 @@ For keypoints only, one can encode the frame index as the `z` coordinate using t
 
 After learning how to augment video frames and associated targets:
 
--   **[Review Core Concepts](../2-core-concepts):** Understand how [Targets](../2-core-concepts/targets.md) (especially `images`) and [Pipelines](../2-core-concepts/pipelines.md) work fundamentally.
+-   **[Review Core Concepts](../2-core-concepts/index.md):** Understand how [Targets](../2-core-concepts/targets.md) (especially `images`) and [Pipelines](../2-core-concepts/pipelines.md) work fundamentally.
 -   **[Refine Your Augmentation Choices](./choosing-augmentations.md):** Consider which transforms are most suitable for video data while maintaining temporal consistency.
 -   **[Optimize Performance](./performance-tuning.md):** Learn how to speed up your pipeline, which is crucial for potentially large video datasets.
 -   **Explore Related Task Guides:** See how targets are handled in other contexts:
@@ -293,5 +293,5 @@ After learning how to augment video frames and associated targets:
     -   [Keypoint Augmentation](./keypoint-augmentations.md)
     -   [Semantic Segmentation](./semantic-segmentation.md)
     -   [Volumetric Augmentation](./volumetric-augmentation.md) (For true 3D data)
--   **[Dive into Advanced Guides](../4-advanced-guides):** Explore custom transforms or serialization if needed for complex video workflows.
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** Explore custom transforms or serialization if needed for complex video workflows.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with transforms to see their effect, keeping temporal consistency in mind.

--- a/docs/3-basic-usage/volumetric-augmentation.md
+++ b/docs/3-basic-usage/volumetric-augmentation.md
@@ -190,5 +190,5 @@ After learning the basics of volumetric augmentation:
 -   **Explore Related Task Guides:**
     -   [Video Augmentation](./video-augmentation.md) (For sequences of 2D frames)
     -   [Semantic Segmentation](./semantic-segmentation.md) (For 2D segmentation concepts)
--   **[Dive into Advanced Guides](../4-advanced-guides):** Learn about creating custom transforms (potentially 3D) or serialization.
+-   **[Dive into Advanced Guides](../4-advanced-guides/index.md):** Learn about creating custom transforms (potentially 3D) or serialization.
 -   **[Visually Explore 2D Transforms](https://explore.albumentations.ai):** Experiment with the 2D transforms that can be applied slice-wise to your volumes.

--- a/docs/4-advanced-guides/creating-custom-transforms.md
+++ b/docs/4-advanced-guides/creating-custom-transforms.md
@@ -629,8 +629,8 @@ Once defined, your custom transform class is used just like any built-in Albumen
 
 Now that you can create your own custom transforms:
 
--   **Integrate Your Transform:** Add your custom transform to pipelines within the [Basic Usage Guides](../3-basic-usage) relevant to your task.
--   **Explore Base Class APIs:** Consult the [API Reference](https://albumentations.ai/api-reference/) for details on `ImageOnlyTransform`, `DualTransform`, `Transform3D`, and other base classes you might inherit from.
+-   **Integrate Your Transform:** Add your custom transform to pipelines within the [Basic Usage Guides](../3-basic-usage/index.md) relevant to your task.
+-   **Explore Base Class APIs:** Consult the [API Reference](https://albumentations.ai/docs/api-reference/) for details on `ImageOnlyTransform`, `DualTransform`, `Transform3D`, and other base classes you might inherit from.
 -   **Handle Advanced Scenarios:** Learn how custom transforms interact with [Additional Targets](./additional-targets.md) or how they can be included in [Serialization](./serialization.md).
 -   **Revisit Core Concepts:** Ensure your custom transform correctly handles [Targets](../2-core-concepts/targets.md) and fits within the [Pipeline](../2-core-concepts/pipelines.md) structure.
 -   **Contribute (Optional):** If your transform is broadly useful, consider contributing it back to the Albumentations library (see the project's contribution guidelines).

--- a/docs/4-advanced-guides/index.md
+++ b/docs/4-advanced-guides/index.md
@@ -16,7 +16,7 @@ This section covers more advanced features and customization options within Albu
 After identifying the advanced topic you need:
 
 -   **Dive into a specific guide:** Read the detailed explanation for additional targets, serialization, or custom transforms.
--   **Apply Advanced Techniques:** Integrate these features into your specific task pipelines (referencing [Basic Usage Guides](../3-basic-usage)).
--   **Consult the [API Reference](https://albumentations.ai/docs/):** Get detailed information on all classes and functions.
--   **Revisit [Core Concepts](../2-core-concepts):** Ensure you have a solid understanding of the fundamentals before tackling advanced features.
+-   **Apply Advanced Techniques:** Integrate these features into your specific task pipelines (referencing [Basic Usage Guides](../3-basic-usage/index.md)).
+-   **Consult the [API Reference](https://albumentations.ai/docs/api-reference):** Get detailed information on all classes and functions.
+-   **Revisit [Core Concepts](../2-core-concepts/index.md):** Ensure you have a solid understanding of the fundamentals before tackling advanced features.
 -   **[Visually Explore Transforms](https://explore.albumentations.ai):** Experiment with standard transforms before creating custom ones.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -97,13 +97,13 @@ transform = A.Compose([
 transformed = transform(image=video)['image']
 ```
 
-See [Working with Video Data](getting-started/video-augmentation.md) for more info.
+See [Working with Video Data](./3-basic-usage/video-augmentation.md) for more info.
 
 ### How to process volumetric data with Albumentations?
 
 Albumentations can process volumetric data by treating it as a sequence of 2D slices. When you pass a volumetric data as a numpy array, Albumentations will apply the same transform with identical parameters to each slice, ensuring temporal consistency.
 
-See [Working with Volumetric Data (3D)](getting-started/volumetric-augmentation.md) for more info.
+See [Working with Volumetric Data (3D)](./3-basic-usage/volumetric-augmentation.md) for more info.
 
 
 ### My computer vision pipeline works with a sequence of images. I want to apply the same augmentations with the same parameters to each image in the sequence. Can Albumentations do it?
@@ -219,7 +219,7 @@ In this example, Resize has an effective probability of being applied as `0.9 * 
 
 ### I created annotations for bounding boxes using labeling service or labeling software. How can I use those annotations in Albumentations?
 
-You need to convert those annotations to one of the formats, supported by Albumentations. For the list of formats, please refer to [this article](getting-started/bounding-boxes-augmentation.md). Consult the documentation of the labeling service to see how you can export annotations in those formats.
+You need to convert those annotations to one of the formats, supported by Albumentations. For the list of formats, please refer to [this article](./3-basic-usage/bounding-boxes-augmentations.md). Consult the documentation of the labeling service to see how you can export annotations in those formats.
 
 ## Integration and Migration
 
@@ -263,7 +263,7 @@ See [this example](../examples/example-hfhub/) for more info.
 
 ### How do I migrate from other augmentation libraries to Albumentations?
 
-If you're migrating from other libraries like torchvision or Kornia, you can refer to our [Library Comparison & Benchmarks](getting-started/library-comparison.md) guide. This guide provides:
+If you're migrating from other libraries like torchvision or Kornia, you can refer to our [Library Comparison](./torchvision-kornia2albumentations.md) guide. This guide provides:
 
 1. Mapping tables showing equivalent transforms between libraries
 2. Performance benchmarks demonstrating Albumentations' speed advantages
@@ -275,4 +275,4 @@ For a quick visual comparison of different augmentations, you can also use our i
 For specific migration examples, see:
 
 - [Migrating from torchvision](examples/migrating-from-torchvision-to-albumentations/)
-- [Performance comparison with other libraries](getting-started/library-comparison.md#performance-comparison)
+- [Performance comparison with other libraries](./benchmarks)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,13 @@ This documentation will guide you through installing the library, understanding 
 
 ## Getting Started
 
-*   **[Introduction](./1-introduction):** Learn what data augmentation is and why it's important.
+*   **[Introduction](./1-introduction/index.md):** Learn what data augmentation is and why it's important.
 *   **[Installation](./1-introduction/installation.md):** Set up Albumentations in your environment.
 
 ## Learning the Basics
 
-*   **[Core Concepts](./2-core-concepts):** Understand the fundamental building blocks: Transforms, Pipelines (Compose), Targets (image, mask, bboxes, keypoints), and Probabilities.
-*   **[Basic Usage Guides](./3-basic-usage):** Find practical examples for common computer vision tasks:
+*   **[Core Concepts](./2-core-concepts/index.md):** Understand the fundamental building blocks: Transforms, Pipelines (Compose), Targets (image, mask, bboxes, keypoints), and Probabilities.
+*   **[Basic Usage Guides](./3-basic-usage/index.md):** Find practical examples for common computer vision tasks:
     *   [Image Classification](./3-basic-usage/image-classification.md)
     *   [Semantic Segmentation](./3-basic-usage/semantic-segmentation.md)
     *   [Object Detection (Bounding Boxes)](./3-basic-usage/bounding-boxes-augmentations.md)
@@ -24,7 +24,7 @@ This documentation will guide you through installing the library, understanding 
 
 ## Advanced Topics
 
-*   **[Advanced Guides](./4-advanced-guides):** Explore more complex features:
+*   **[Advanced Guides](./4-advanced-guides/index.md):** Explore more complex features:
     *   [Using Additional Targets](./4-advanced-guides/additional-targets.md)
     *   [Creating Custom Transforms](./4-advanced-guides/creating-custom-transforms.md)
     *   [Serialization](./4-advanced-guides/serialization.md)


### PR DESCRIPTION
## Summary by Sourcery

Update internal documentation links to use relative paths with explicit file extensions

Documentation:
- Update documentation links across multiple markdown files to use consistent relative path notation with explicit .md file extensions

Chores:
- Update pre-commit configuration to use latest Ruff linter version