### PR TITLE
Update about grayscale

### DIFF
--- a/docs/2-core-concepts/pipelines.md
+++ b/docs/2-core-concepts/pipelines.md
@@ -133,6 +133,8 @@ compose = A.Compose(
 
 `Compose` includes automatic preprocessing for grayscale images to ensure compatibility with all transforms:
 
+- **Transform requirement**: All individual transforms in Albumentations require grayscale images to have a channel dimension `(H, W, 1)`
+- **Compose convenience**: Automatically handles both `(H, W)` and `(H, W, 1)` formats
 - **Channel dimension handling**: If you pass a grayscale image without a channel dimension (e.g., shape `(H, W)`),
   `Compose` automatically adds one during preprocessing, making it `(H, W, 1)`
 - **Postprocessing cleanup**: If a channel dimension was added, it's automatically removed in the output,

--- a/docs/2-core-concepts/pipelines.md
+++ b/docs/2-core-concepts/pipelines.md
@@ -105,6 +105,9 @@ compose = A.Compose(
     Default: `None`.
 
 *   **`seed` (int | None):** Controls the reproducibility of random augmentations *within this specific `Compose` instance*.
+    When provided, this sets the random seed for all transforms in the pipeline, ensuring that the same sequence
+    of random parameters is generated each time the pipeline is called with identical inputs.
+    Default: `None` (no fixed seed).
 
     **When seed is set (int):**
     *   Creates a fixed internal random state
@@ -120,11 +123,26 @@ compose = A.Compose(
     on augmentations. See the [Creating Custom Transforms Guide](../4-advanced-guides/creating-custom-transforms.md#reproducibility-and-random-number-generation)
     for how to use the seeded generators in custom transforms. Default: `None`.
 
-*   **`save_applied_params` (bool):** If `True`, the dictionary returned by the `Compose` call will include
-    an extra key `'applied_transforms'`. The value will be a list of dictionaries, where each dictionary
-    contains the name of an applied transform and the exact parameters it used for that specific call.
+*   **`save_applied_params` (bool):** If `True`, after processing each transform, Compose saves the actual parameters used
+    by that transform in the result dictionary under the key `applied_params`.
+    This includes both static parameters and any random values that were sampled.
+    Useful for debugging or when you need to know exactly what augmentations were applied.
+    Default: `False`.
 
-    Useful for debugging, replay, or analysis. Default: `False`.
+### Grayscale Image Preprocessing
+
+`Compose` includes automatic preprocessing for grayscale images to ensure compatibility with all transforms:
+
+- **Channel dimension handling**: If you pass a grayscale image without a channel dimension (e.g., shape `(H, W)`),
+  `Compose` automatically adds one during preprocessing, making it `(H, W, 1)`
+- **Postprocessing cleanup**: If a channel dimension was added, it's automatically removed in the output,
+  maintaining the original format
+- **Transparent to users**: This happens automatically - you can pass grayscale images in either format
+
+This preprocessing ensures that all transforms work consistently regardless of whether you provide grayscale
+images with or without an explicit channel dimension. However, if you use transforms directly without `Compose`,
+you must ensure grayscale images have the channel dimension. See the [Grayscale Image Handling](../2-core-concepts/targets.md#grayscale-image-handling)
+section for more details.
 
 ## Dynamic Pipeline Modification
 

--- a/docs/3-basic-usage/bounding-boxes-augmentations.md
+++ b/docs/3-basic-usage/bounding-boxes-augmentations.md
@@ -128,20 +128,20 @@ image = cv2.imread(image_path)
 image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
 # Prepare Bounding Boxes (example using 'coco' format)
-# Each inner list is [x_min, y_min, bbox_width, bbox_height]
+# Each row is [x_min, y_min, bbox_width, bbox_height]
 bboxes = np.array([
     [23, 74, 295, 388],
     [377, 294, 252, 161],
     [333, 421, 49, 49],
-])
+], dtype=np.float32)
 
 # Prepare Labels (using the name specified in label_fields)
-class_labels = ['dog', 'cat', 'sports ball']
+class_labels = np.array(['dog', 'cat', 'sports ball'])
 # Example with multiple label fields if defined in BboxParams:
-# class_categories = ['animal', 'animal', 'item']
+# class_categories = np.array(['animal', 'animal', 'item'])
 ```
 
-Albumentations expects `bboxes` as a NumPy array `(num_boxes, 4)`. Each inner list/row must contain the 4 coordinate values according to the specified `format`.
+Albumentations expects `bboxes` as a NumPy array with shape `(num_boxes, 4)`. Each row must contain the 4 coordinate values according to the specified `format`.
 
 ### Step 4: Apply the Pipeline
 
@@ -186,18 +186,18 @@ def draw_bboxes(image_np, bboxes, labels, class_name_map=None, color=(0, 255, 0)
     font_scale = 0.5
     font_thickness = 1
 
-    if not isinstance(bboxes, (list, np.ndarray)):
-        print(f"Warning: bboxes is not a list or ndarray: {type(bboxes)}")
+    if not isinstance(bboxes, np.ndarray):
+        print(f"Warning: bboxes is not an ndarray: {type(bboxes)}")
         return img_res
-    if not isinstance(labels, (list, np.ndarray)):
-        print(f"Warning: labels is not a list or ndarray: {type(labels)}")
+    if not isinstance(labels, np.ndarray):
+        print(f"Warning: labels is not an ndarray: {type(labels)}")
         # Attempt to proceed if labels seem usable, otherwise return
         if len(bboxes) != len(labels):
             print("Warning: bbox and label length mismatch, cannot draw labels.")
-            labels = ['?' for _ in bboxes] # Placeholder
-        elif not all(isinstance(l, (str, int, float)) for l in labels):
-             print("Warning: labels contain non-primitive types, cannot draw reliably.")
-             labels = ['?' for _ in bboxes]
+            labels = np.array(['?' for _ in bboxes]) # Placeholder
+        elif labels.dtype == np.object:
+             print("Warning: labels contain object dtype, converting to string.")
+             labels = labels.astype(str)
 
     for bbox, label in zip(bboxes, labels):
         # Assuming bbox format allows direct conversion to int x_min, y_min, x_max, y_max

--- a/docs/3-basic-usage/bounding-boxes-augmentations.md
+++ b/docs/3-basic-usage/bounding-boxes-augmentations.md
@@ -195,7 +195,7 @@ def draw_bboxes(image_np, bboxes, labels, class_name_map=None, color=(0, 255, 0)
         if len(bboxes) != len(labels):
             print("Warning: bbox and label length mismatch, cannot draw labels.")
             labels = np.array(['?' for _ in bboxes]) # Placeholder
-        elif labels.dtype == np.object:
+        elif labels.dtype == object:
              print("Warning: labels contain object dtype, converting to string.")
              labels = labels.astype(str)
 

--- a/docs/3-basic-usage/keypoint-augmentations.md
+++ b/docs/3-basic-usage/keypoint-augmentations.md
@@ -109,22 +109,22 @@ Keypoints can be stored on the disk in different serialization formats: JSON, XM
 
 After you read the data from the disk, you need to prepare keypoints for Albumentations.
 
-Albumentations expects that keypoint will be represented as a list of lists. Each list contains information about a single keypoint. A definition of keypoint should have two to four elements depending on the selected format of keypoints. The first two elements are x and y coordinates of a keypoint in pixels (or y and x coordinates in the `yx` format). The third and fourth elements may be the angle and the scale of keypoint if you select a format that uses those values.
+Albumentations expects keypoints to be represented as a NumPy array with shape `(num_keypoints, 2+)`. Each row contains information about a single keypoint. A keypoint definition should have two to four elements depending on the selected format. The first two elements are x and y coordinates of a keypoint in pixels (or y and x coordinates in the `yx` format). The third and fourth elements may be the angle and the scale of keypoint if you select a format that uses those values.
 
-## Step 4. Pass an image and keypoints to the augmentation pipeline and receive augmented images and boxes.
+## Step 4. Pass an image and keypoints to the augmentation pipeline and receive augmented images and keypoints.
 
 Let's say you have an example image with five keypoints.
 
-A list with those five keypoints' coordinates in the `xy` format will look the following:
+A NumPy array with those five keypoints' coordinates in the `xy` format will look like the following:
 
 ```python
 keypoints = np.array([
-    (264, 203),
-    (86, 88),
-    (254, 160),
-    (193, 103),
-    (65, 341),
-])
+    [264, 203],
+    [86, 88],
+    [254, 160],
+    [193, 103],
+    [65, 341],
+], dtype=np.float32)
 ```
 
 Then you pass those keypoints to the `transform` function along with the image and receive the augmented versions of image and keypoints.
@@ -144,16 +144,16 @@ If you set `remove_invisible` to `False` in `keypoint_params`, then Albumentatio
 **When `remove_invisible` is set to `False` Albumentations will return all keypoints, even those located outside the image**
 
 
-If keypoints have associated class labels, you need to create a list that contains those labels:
+If keypoints have associated class labels, you need to create a NumPy array that contains those labels:
 
 ```python
-class_labels = [
+class_labels = np.array([
     'left_elbow',
     'right_elbow',
     'left_wrist',
     'right_wrist',
     'right_hip',
-]
+])
 ```
 
 Also, you need to declare the name of the argument to `transform` that will contain those labels. For declaration, you need to use the `label_fields` parameters of `A.KeypointParams`.
@@ -177,7 +177,7 @@ transformed_keypoints = transformed['keypoints']
 transformed_class_labels = transformed['class_labels']
 ```
 
-Note that `label_fields` expects a list, so you can set multiple fields that contain labels for your keypoints. So if you declare Compose like
+Note that `label_fields` expects a list of field names, so you can set multiple fields that contain labels for your keypoints. So if you declare Compose like
 
 ```python
 transform = A.Compose([
@@ -189,15 +189,15 @@ transform = A.Compose([
 you can use those multiple arguments to pass info about class labels, like
 
 ```python
-class_labels = [
+class_labels = np.array([
     'left_elbow',
     'right_elbow',
     'left_wrist',
     'right_wrist',
     'right_hip',
-]
+])
 
-class_sides = ['left', 'right', 'left', 'right', 'right']
+class_sides = np.array(['left', 'right', 'left', 'right', 'right'])
 
 transformed = transform(image=image, keypoints=keypoints, class_labels=class_labels, class_sides=class_sides)
 transformed_class_sides = transformed['class_sides']

--- a/docs/3-basic-usage/video-augmentation.md
+++ b/docs/3-basic-usage/video-augmentation.md
@@ -112,9 +112,9 @@ Here are potential approaches:
 This approach flattens all bounding boxes (or keypoints) from all frames into a single list and uses `label_fields` to track the original frame index for each target.
 
 1.  **Prepare Data:**
-    *   Create a single flat list `all_bboxes` containing all boxes from all frames.
-    *   Create a corresponding list `frame_indices` indicating the frame index (0 to N-1) for each box in `all_bboxes`.
-    *   Create a list `class_labels` for the actual class of each box in `all_bboxes`.
+    *   Create a single flat array `all_bboxes` containing all boxes from all frames.
+*   Create a corresponding array `frame_indices` indicating the frame index (0 to N-1) for each box in `all_bboxes`.
+*   Create an array `class_labels` for the actual class of each box in `all_bboxes`.
 
     ```python
     # Conceptual Example Data Preparation (BBoxes)
@@ -123,8 +123,8 @@ This approach flattens all bounding boxes (or keypoints) from all frames into a 
     # Frame 1 boxes: [[20, 20, 60, 60]] Label: ['cat']
 
     all_bboxes = np.array([[10, 10, 50, 50], [70, 70, 90, 90], [20, 20, 60, 60]])
-    frame_indices = [0, 0, 1] # Frame ID for each box
-    class_labels = ['cat', 'dog', 'cat'] # Actual class label for each box
+    frame_indices = np.array([0, 0, 1]) # Frame ID for each box
+    class_labels = np.array(['cat', 'dog', 'cat']) # Actual class label for each box
 
     # Conceptual Example Data Preparation (Keypoints)
     # Assume video has 2 frames (N=2)
@@ -137,8 +137,8 @@ This approach flattens all bounding boxes (or keypoints) from all frames into a 
         [25, 25],
         [35, 35]
     ], dtype=np.float32)
-    kp_frame_indices = [0, 0, 1]
-    kp_class_labels = ['eye', 'nose', 'eye']
+    kp_frame_indices = np.array([0, 0, 1])
+    kp_class_labels = np.array(['eye', 'nose', 'eye'])
     ```
 
 2.  **Define Pipeline:** Include `frame_indices` (or similar) in `label_fields` for `bbox_params` or `keypoint_params`.
@@ -226,7 +226,7 @@ For keypoints only, one can encode the frame index as the `z` coordinate using t
         [25, 25, 0],
         [35, 35, 1]
     ], dtype=np.float32)
-    kp_class_labels = ['eye', 'nose', 'eye']
+    kp_class_labels = np.array(['eye', 'nose', 'eye'])
     ```
 
 2.  **Define Pipeline:** Use `format='xyz'`.


### PR DESCRIPTION
## Summary by Sourcery

Revise and expand documentation to enforce NumPy array inputs, streamline transform compatibility guidance, and introduce automatic grayscale handling in pipelines.

Documentation:
- Clarify that all targets (images, masks, bboxes, keypoints, labels) must be provided as NumPy arrays and drop list support
- Add a dedicated Grayscale Image Handling section describing Compose’s automatic channel-dimension management and cleanup
- Simplify the Target Compatibility Matrix with categorized transform types and detailed descriptions
- Enhance Compose API docs with an explanation of the seed parameter, updated save_applied_params behavior, and grayscale preprocessing overview
- Update code examples in keypoint, bounding-box, and video augmentation guides to consistently use NumPy arrays
- Replace outdated links with the external Supported Targets by Transform reference