### PR TITLE
Fix license language

### DIFF
--- a/docs/1-introduction/index.md
+++ b/docs/1-introduction/index.md
@@ -1,6 +1,6 @@
 # Getting Started with Albumentations
 
-> **Note:** Looking for the actively maintained version? Check out **[AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX)** - a 100% drop-in replacement with improved performance, bug fixes, and new features. Learn more in our [Installation Guide](./installation.md).
+> **Note:** Check out **[AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX)** with improved performance, bug fixes, and new features. Learn more in our [Installation Guide](./installation.md).
 
 Welcome to Albumentations! If you're looking to boost your computer vision model's performance and robustness, you're in the right place. Albumentations is a powerful, flexible, and fast library for image augmentation.
 

--- a/docs/1-introduction/installation.md
+++ b/docs/1-introduction/installation.md
@@ -15,10 +15,6 @@ Albumentations requires Python 3.9 or higher. We recommend using the latest stab
 AlbumentationsX is dual-licensed (AGPL/Commercial). For more information about licensing, see our [License Guide](../license.md).
 
 ```bash
-# Uninstall any existing installation if needed
-pip uninstall albumentations
-
-# Install AlbumentationsX
 pip install -U albumentationsx
 ```
 

--- a/docs/1-introduction/installation.md
+++ b/docs/1-introduction/installation.md
@@ -15,7 +15,7 @@ Albumentations requires Python 3.9 or higher. We recommend using the latest stab
 AlbumentationsX is dual-licensed (AGPL/Commercial). For more information about licensing, see our [License Guide](../license.md).
 
 ```bash
-# Uninstall original Albumentations if installed
+# Uninstall any existing installation if needed
 pip uninstall albumentations
 
 # Install AlbumentationsX
@@ -34,32 +34,15 @@ transform = A.Compose([
 ])
 ```
 
-### Original Albumentations (MIT Licensed)
 
-If you prefer to use the original MIT-licensed version (no longer actively maintained):
 
-```bash
-pip install -U albumentations
-```
 
-### From Conda Forge
-
-If you are using Anaconda or Miniconda:
-
-```bash
-conda install -c conda-forge albumentations
-```
 
 ### From GitHub (Latest Development Version)
 
 For AlbumentationsX:
 ```bash
 pip install -U git+https://github.com/albumentations-team/AlbumentationsX
-```
-
-For original Albumentations:
-```bash
-pip install -U git+https://github.com/albumentations-team/albumentations
 ```
 
 **Note:** Installing from the `main` branch might give you newer features but could potentially be less stable than official releases.
@@ -74,9 +57,6 @@ Both Albumentations and AlbumentationsX rely heavily on OpenCV.
     ```bash
     # For AlbumentationsX
     pip install -U albumentationsx --no-binary albumentationsx
-
-    # For original Albumentations
-    pip install -U albumentations --no-binary albumentations
     ```
     In most standard cases, this flag is **not** required.
 

--- a/docs/1-introduction/installation.md
+++ b/docs/1-introduction/installation.md
@@ -4,10 +4,9 @@ Albumentations requires Python 3.9 or higher. We recommend using the latest stab
 
 ## Installation Methods
 
-### AlbumentationsX (Recommended - Drop-in Replacement)
+### AlbumentationsX (Recommended)
 
-**AlbumentationsX** is the next-generation successor to Albumentations, offering:
-- 🚀 100% API compatibility - no code changes required
+**AlbumentationsX** offers:
 - ⚡ Improved performance and bug fixes
 - 🔧 Active maintenance and new features
 - 📊 Better support for production environments
@@ -18,9 +17,8 @@ AlbumentationsX is dual-licensed (AGPL/Commercial). For more information about l
 pip install -U albumentationsx
 ```
 
-Your existing code continues to work without any changes:
+Here's a basic example:
 ```python
-# Same import - no changes needed!
 import albumentations as A
 
 transform = A.Compose([

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,7 +5,7 @@ This FAQ covers common questions about Albumentations, from basic setup to advan
 - Installation troubleshooting and configuration
 - Working with different data formats (images, video, volumetric data)
 - Advanced usage patterns and best practices
-- Integration with other tools and migration from other libraries
+- Integration with other tools and switching from other libraries
 
 If you don't find an answer to your question, please check the [GitHub Issues for AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX/issues), or join our [Discord community](https://discord.gg/AmMnDBdzYs).
 
@@ -65,11 +65,6 @@ AlbumentationsX is the next-generation successor to Albumentations. It's a 100% 
 - Professional support options
 - Dual licensing (AGPL/Commercial)
 
-
-
-### Do I need to change my code when switching to AlbumentationsX?
-
-No! AlbumentationsX is designed as a complete drop-in replacement. Simply uninstall `albumentations` and install `albumentationsx`. Your existing code will work without any modifications.
 
 ### What is dual licensing and why was it introduced?
 
@@ -437,7 +432,7 @@ You need to convert those annotations to one of the formats, supported by Albume
 
 Consult the documentation of the labeling service to see how you can export annotations in those formats.
 
-## Integration and Migration
+## Integration
 
 ### How to save and load augmentation transforms to HuggingFace Hub?
 
@@ -477,18 +472,18 @@ loaded_transform = A.Compose.from_pretrained("qubvel-hf/albu", key="train")
 
 See [this example](https://www.albumentations.ai/docs/examples/example-hfhub/) for more info.
 
-### How do I migrate from other augmentation libraries to Albumentations?
+### How do I switch from other augmentation libraries to AlbumentationsX?
 
-If you're migrating from other libraries like torchvision or Kornia, you can refer to our [Library Comparison](./torchvision-kornia2albumentations.md) guide. This guide provides:
+If you're switching from other libraries like torchvision or Kornia, you can refer to our [Library Comparison](./torchvision-kornia2albumentations.md) guide. This guide provides:
 
 1. Mapping tables showing equivalent transforms between libraries
-2. Performance benchmarks demonstrating Albumentations' speed advantages
-3. Code examples for common migration scenarios
+2. Performance benchmarks demonstrating AlbumentationsX's speed advantages
+3. Code examples for common switching scenarios
 4. Key differences in implementation and parameter handling
 
 For a quick visual comparison of different augmentations, you can also use our interactive tool at [explore.albumentations.ai](https://explore.albumentations.ai) to see how transforms affect images before implementing them.
 
-For specific migration examples, see:
+For specific examples, see:
 
 - [Migrating from torchvision](https://www.albumentations.ai/docs/examples/migrating-from-torchvision-to-albumentations/)
 - [Performance comparison with other libraries](./benchmarks)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,7 +7,7 @@ This FAQ covers common questions about Albumentations, from basic setup to advan
 - Advanced usage patterns and best practices
 - Integration with other tools and migration from other libraries
 
-If you don't find an answer to your question, please check the GitHub Issues for [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX/issues) or [original Albumentations](https://github.com/albumentations-team/albumentations/issues), or join our [Discord community](https://discord.gg/AmMnDBdzYs).
+If you don't find an answer to your question, please check the [GitHub Issues for AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX/issues), or join our [Discord community](https://discord.gg/AmMnDBdzYs).
 
 ## Installation
 
@@ -65,7 +65,7 @@ AlbumentationsX is the next-generation successor to Albumentations. It's a 100% 
 - Professional support options
 - Dual licensing (AGPL/Commercial)
 
-The original Albumentations remains MIT licensed but is no longer actively maintained.
+
 
 ### Do I need to change my code when switching to AlbumentationsX?
 
@@ -77,7 +77,7 @@ AlbumentationsX uses dual licensing:
 - **AGPL-3.0**: Free for open source projects that are also AGPL-licensed
 - **Commercial License**: Required for proprietary/commercial use or projects with non-AGPL licenses
 
-This model ensures sustainable development of the library. After 7 years of MIT licensing with minimal financial support, dual licensing provides resources for full-time maintenance and development. See our [License Guide](./license.md) for details.
+This model ensures sustainable development of the library. Dual licensing provides resources for full-time maintenance and development. See our [License Guide](./license.md) for details.
 
 ### Do I need to pay to use AlbumentationsX?
 
@@ -88,18 +88,14 @@ You need a commercial license if:
 
 You can use it for free only if your entire project is licensed under AGPL-3.0.
 
-### Can I continue using the original MIT-licensed Albumentations?
 
-Yes! The original Albumentations remains available and MIT licensed. However, it's no longer actively maintained, so you won't receive bug fixes or new features.
 
-### What is AGPL and how does it differ from MIT?
+### What is AGPL?
 
 AGPL (Affero General Public License) is a copyleft license that requires:
 - If you use AGPL software, your entire project must also be AGPL
 - You cannot mix AGPL code with MIT/Apache/BSD licensed code without converting everything to AGPL
 - If you distribute the software or run it as a network service, you must provide source code
-
-MIT license has no such requirements - you can use MIT code in any project with any license.
 
 ### How do I disable telemetry in AlbumentationsX?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,8 +19,6 @@ Try to update `pip` by running the following command:
 python -m pip install --upgrade pip
 ```
 
-
-
 ### How to make Albumentations use one CPU core?
 
 Albumentations do not use multithreading by default, but libraries it depends on (like opencv) may use multithreading. To make Albumentations use one CPU core, you can set the following environment variables:
@@ -58,7 +56,7 @@ This should be done at the beginning of your script or before creating the DataL
 
 ### What is AlbumentationsX?
 
-AlbumentationsX is the next-generation successor to Albumentations. It's a 100% drop-in replacement that offers:
+AlbumentationsX offers:
 - Active maintenance and bug fixes
 - Performance improvements
 - New features and transforms

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 > - ✅ **100% drop-in replacement** - no code changes required
 > - ⚡ **Better performance** with bug fixes and new features
 > - 🔧 **Active maintenance** and professional support
-> - 📄 **Dual licensed** (AGPL/Commercial) - see our [License Guide](./license.md)
+> - 📄 **Licensed** under AGPL/Commercial - see our [License Guide](./license.md)
 >
 > ```bash
 > pip uninstall albumentations  # If you have it installed
@@ -52,9 +52,7 @@ This documentation will guide you through installing the library, understanding 
 *   **[Benchmarks](./benchmarks):** Performance comparison results.
 *   **[Supported Targets by Transform](./reference/supported-targets-by-transform.md):** Check which transforms work with images, masks, bounding boxes, keypoints, etc.
 *   **[API Reference](./api-reference)**
-*   **GitHub Repositories:**
-    *   [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX) - Active development (dual licensed)
-    *   [Original Albumentations](https://github.com/albumentations-team/albumentations) - MIT licensed (maintenance mode)
+*   **[GitHub Repository](https://github.com/albumentations-team/AlbumentationsX):** Active development
 *   **[Examples Repository](https://github.com/albumentations-team/albumentations_examples):** Many practical examples.
 
 We hope this documentation helps you leverage the full power of Albumentations!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,19 @@
 # Welcome to Albumentations Documentation!
 
-> 🚀 **Important: AlbumentationsX - The Next Generation**
+> 🚀 **Important: AlbumentationsX**
 >
-> **[AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX)** is now available as the actively maintained successor to Albumentations:
+> **[AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX)** is now available:
 >
-> - ✅ **100% drop-in replacement** - no code changes required
+
 > - ⚡ **Better performance** with bug fixes and new features
 > - 🔧 **Active maintenance** and professional support
 > - 📄 **Licensed** under AGPL/Commercial - see our [License Guide](./license.md)
 >
 > ```bash
-> pip uninstall albumentations  # If you have it installed
-> pip install albumentationsx   # Install the new version
+> pip install albumentationsx
 > ```
 >
-> Your existing code continues to work exactly as before! Learn more in our [Installation Guide](./1-introduction/installation.md).
+> Learn more in our [Installation Guide](./1-introduction/installation.md).
 
 Albumentations is a fast and flexible library for image augmentation. Whether you're working on classification, segmentation, object detection, or other computer vision tasks, Albumentations provides a comprehensive set of transforms and a powerful pipeline framework.
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,11 +1,10 @@
 # AlbumentationsX License Guide
 
-AlbumentationsX is designed as a 100% drop-in replacement with a sustainable dual licensing model. This guide explains the licensing model and what it means for you.
+AlbumentationsX uses a sustainable dual licensing model. This guide explains the licensing model and what it means for you.
 
 ## Quick Summary
 
 - **AlbumentationsX** is dual-licensed: AGPL-3.0 (open source) / Commercial
-- **No code changes required** - AlbumentationsX is a drop-in replacement
 - **Open source projects** can use AlbumentationsX for free under AGPL
 - **Commercial projects** need a commercial license for proprietary use
 
@@ -64,7 +63,7 @@ pip install albumentationsx
 
 Your code stays the same:
 ```python
-import albumentations as A  # Same import!
+import albumentations as A
 
 transform = A.Compose([
     A.RandomCrop(width=256, height=256),
@@ -94,10 +93,6 @@ You have two paths:
    - This means abandoning MIT, Apache, BSD, or other permissive licenses
    - Must provide source code when distributing
    - Valid approach if AGPL aligns with your project goals
-
-
-
-
 
 ## Benefits of the Dual License Model
 
@@ -144,10 +139,6 @@ Projects like [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) hav
 ### Q: What about existing projects?
 
 **A:** To use AlbumentationsX, you need to comply with the licensing terms - either use AGPL for your entire project or purchase a commercial license.
-
-### Q: Is the API really 100% compatible?
-
-**A:** Yes! AlbumentationsX is designed as a drop-in replacement. Your existing code will work without modifications.
 
 ### Q: How do I know if I need a commercial license?
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,11 +1,10 @@
 # AlbumentationsX License Guide
 
-AlbumentationsX is the next-generation successor to Albumentations, designed as a 100% drop-in replacement while introducing a sustainable dual licensing model. This guide explains the licensing changes, why they were made, and what they mean for you.
+AlbumentationsX is designed as a 100% drop-in replacement with a sustainable dual licensing model. This guide explains the licensing model and what it means for you.
 
 ## Quick Summary
 
 - **AlbumentationsX** is dual-licensed: AGPL-3.0 (open source) / Commercial
-- **Original Albumentations** remains MIT licensed but is no longer actively maintained
 - **No code changes required** - AlbumentationsX is a drop-in replacement
 - **Open source projects** can use AlbumentationsX for free under AGPL
 - **Commercial projects** need a commercial license for proprietary use
@@ -14,7 +13,7 @@ AlbumentationsX is the next-generation successor to Albumentations, designed as 
 
 ### Background
 
-After 7 years of MIT licensing, AlbumentationsX transitions to a dual license model. This change comes from the reality of maintaining a widely-used open source project:
+AlbumentationsX uses a dual license model. This approach ensures sustainable maintenance of a widely-used open source project:
 
 - The project has grown to serve thousands of companies and researchers worldwide
 - Maintenance, bug fixes, and feature development require significant time investment
@@ -82,7 +81,7 @@ transform = A.Compose([
 
 ### For Commercial/Proprietary Projects
 
-You have three paths:
+You have two paths:
 
 1. **Purchase a Commercial License**
    - Continue using AlbumentationsX in proprietary software
@@ -96,24 +95,9 @@ You have three paths:
    - Must provide source code when distributing
    - Valid approach if AGPL aligns with your project goals
 
-3. **Stay on Original Albumentations**
-   - Continue using the MIT-licensed version
-   - No license fees required
-   - Note: No new features or bug fixes
 
-## Comparison Table
 
-| Feature | Albumentations (Original) | AlbumentationsX |
-|---------|--------------------------|-----------------|
-| **License** | MIT | Dual: AGPL-3.0 / Commercial |
-| **Active Maintenance** | ❌ No | ✅ Yes |
-| **New Features** | ❌ No | ✅ Yes |
-| **Bug Fixes** | ❌ No | ✅ Yes |
-| **Performance Improvements** | ❌ No | ✅ Yes |
-| **Code Changes Required** | - | None (drop-in replacement) |
-| **Free for Open Source** | ✅ Yes | ✅ Yes (AGPL projects only) |
-| **Free for MIT/Apache/BSD Projects** | ✅ Yes | ❌ No (requires commercial license) |
-| **Free for Commercial Use** | ✅ Yes | ❌ No (requires commercial license) |
+
 
 ## Benefits of the Dual License Model
 
@@ -157,11 +141,9 @@ Projects like [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) hav
 
 **A:** Yes! You can evaluate AlbumentationsX in development. A commercial license is only required for production deployment in proprietary systems.
 
-### Q: What about existing projects using Albumentations?
+### Q: What about existing projects?
 
-**A:** You can either:
-- Stay on the original MIT-licensed Albumentations (no changes needed)
-- Upgrade to AlbumentationsX and comply with the new licensing terms
+**A:** To use AlbumentationsX, you need to comply with the licensing terms - either use AGPL for your entire project or purchase a commercial license.
 
 ### Q: Is the API really 100% compatible?
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -164,26 +164,6 @@ The only case where you DON'T need a commercial license is if your entire projec
 
 **A:** Contributors grant rights to use their contributions under both AGPL and commercial licenses, enabling the dual licensing model.
 
-## Migration Guide
-
-### From Albumentations to AlbumentationsX
-
-```bash
-# Step 1: Uninstall original
-pip uninstall albumentations
-
-# Step 2: Install AlbumentationsX
-pip install albumentationsx
-
-# Step 3: There is no step 3 - your code works as-is!
-```
-
-### Verification
-
-```python
-import albumentations as A
-print(A.__version__)  # Should show AlbumentationsX version
-```
 
 ## Support
 


### PR DESCRIPTION
## Summary by Sourcery

Streamline and update documentation to clarify AlbumentationsX’s dual licensing model, remove outdated references to the original package and migration steps, and unify branding across docs.

Enhancements:
- Simplify the license guide by emphasizing the dual licensing model and removing deprecated third paths, comparison table, and migration section
- Update the FAQ to reflect licensing changes, rephrase migration guidance as switching, and remove references to the original Albumentations
- Revise installation and introduction pages to remove instructions for the original package, streamline content for AlbumentationsX, and update branding language